### PR TITLE
Add sightly use-api vars (use,currentPage) to lint

### DIFF
--- a/templates/aem-multimodule-project/content/pom.xml
+++ b/templates/aem-multimodule-project/content/pom.xml
@@ -70,7 +70,7 @@
                 <configuration>
                     <sourceJsFolder>src/main/content/jcr_root</sourceJsFolder>
                     <failOnIssues>true</failOnIssues>
-                    <predefinedVars>jQuery,window,\$,use,currentPage</predefinedVars>
+                    <predefinedVars>jQuery,window,\$,use,properties,pageProperties,inheritedPageProperties,component,componentContext,currentDesign,currentNode,currentPage,currentSession,currentStyle,designer,editContext,log,out,pageManager,reader,request,resource,resourceDesign,resourcePage,response,sling,slyWcmHelper,wcmmode,xssAPI</predefinedVars>
                     <excludes>
                         <exclude>**/extensions/**/*.js</exclude>
                         <exclude>**/vendor/**/*.js</exclude>

--- a/templates/aem-multimodule-project/content/pom.xml
+++ b/templates/aem-multimodule-project/content/pom.xml
@@ -70,7 +70,7 @@
                 <configuration>
                     <sourceJsFolder>src/main/content/jcr_root</sourceJsFolder>
                     <failOnIssues>true</failOnIssues>
-                    <predefinedVars>jQuery,window,\$</predefinedVars>
+                    <predefinedVars>jQuery,window,\$,use,currentPage</predefinedVars>
                     <excludes>
                         <exclude>**/extensions/**/*.js</exclude>
                         <exclude>**/vendor/**/*.js</exclude>


### PR DESCRIPTION
Currently sightly js files are breaking the jslint tests under enableCodeQuality profile due to undefined use(...) and currentPage objects (for example).  

For example the following sightly js file:
```
use(function() {
    'use strict';
    return {
      "root": function() { return currentPage.getAbsoluteParent(2); }
    };
});
```

Generates the following errors in the maven build:
```
[INFO] Parsing: apps/myapp/components/content/mycomponent/mycomponent.js
[ERROR] navigation.js:1:1:'use' has not been fully defined yet.
[ERROR] navigation.js:4:35:'currentPage' is not defined.
```
Added a couple of predefined vars to the lint tests to prevent failures.  Not sure what the entire list of predefined vars for sightly are though, perhaps [defineObjects](https://docs.adobe.com/docs/en/cq/5-6/howto/taglib.html#<cq:defineObjects>)