### PR TITLE
Removed duplicate definition of javadoc-plugin

### DIFF
--- a/templates/aem-multimodule-project/pom.xml
+++ b/templates/aem-multimodule-project/pom.xml
@@ -118,6 +118,11 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <version>2.9.1</version>
+                    <configuration>
+                        <excludePackageNames>
+                            *.impl
+                        </excludePackageNames>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.sling</groupId>
@@ -198,15 +203,6 @@
                             <version>0.0.1</version>
                         </dependency>
                     </dependencies>
-                </plugin>
-                <plugin>
-                    <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>2.9</version>
-                    <configuration>
-                        <excludePackageNames>
-                            *.impl
-                        </excludePackageNames>
-                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
Removed duplicate definition of maven-javadoc-plugin.  Maven was complaining that there were multiple versions of the javadoc plugin.  As the javadoc plugin was declared outside of the quality profile group the other (later) plugin remains.