### PR TITLE
Add an optional config module

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ Below are all of the options available in the current version. To specify an opt
 | Dispatcher Artifact ID                                    | example-project.dispatcher         | dispatcherArtifactId           |
 | Folder to create under `/apps`                            | my-aem-project                     | appsFolderName                 |
 | Folder to use under `/content`                            | my-aem-project                     | contentFolderName              |
+| Include a separate module for configurations              | no                                 | generateConfigArtifact         |
+| Config Artifact ID                                        | example-project.config             | configArtifactId               |
 | Create AEM Editable Templates folders?                    | yes                                | createEditableTemplatesStructure |
 | Folder to create under `/conf`                            | my-aem-project                     | confFolderName                 |
 | Create a site design?                                     | no                                 | createDesign                   |

--- a/templates/aem-multimodule-project/config/pom.xml
+++ b/templates/aem-multimodule-project/config/pom.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <!-- ====================================================================== -->
+    <!-- P A R E N T P R O J E C T D E S C R I P T I O N -->
+    <!-- ====================================================================== -->
+    <parent>
+        <groupId>${groupId}</groupId>
+        <artifactId>${artifactId}</artifactId>
+        <version>${version}</version>
+    </parent>
+
+    <!-- ====================================================================== -->
+    <!-- P R O J E C T D E S C R I P T I O N -->
+    <!-- ====================================================================== -->
+
+    <artifactId>${configArtifactId}</artifactId>
+    <packaging>content-package</packaging>
+    <name>${projectName} Configuration Content Package</name>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/content/jcr_root</directory>
+                <filtering>false</filtering>
+                <excludes>
+                    <exclude>**/.vlt</exclude>
+                    <exclude>**/.vltignore</exclude>
+                </excludes>
+            </resource>
+        </resources>
+
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <configuration>
+                    <includeEmptyDirs>true</includeEmptyDirs>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>com.day.jcr.vault</groupId>
+                <artifactId>content-package-maven-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <group>${packageGroup}</group>
+                    <filterSource>src/main/content/META-INF/vault/filter.xml</filterSource>
+                    <targetURL>http://\${crx.host}:\${crx.port}/crx/packmgr/service.jsp</targetURL>
+                    <properties>
+                        <acHandling>merge_preserve</acHandling>
+                    </properties>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    <profiles>
+        <profile>
+            <id>autoInstallPackage</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.day.jcr.vault</groupId>
+                        <artifactId>content-package-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>install-content-package</id>
+                                <phase>install</phase>
+                                <goals>
+                                    <goal>install</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>autoInstallPackagePublish</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.day.jcr.vault</groupId>
+                        <artifactId>content-package-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>install-content-package-publish</id>
+                                <phase>install</phase>
+                                <goals>
+                                    <goal>install</goal>
+                                </goals>
+                                <configuration>
+                                    <targetURL>http://\${publish.crx.host}:\${publish.crx.port}/crx/packmgr/service.jsp</targetURL>
+                                    <userId>\${publish.crx.username}</userId>
+                                    <password>\${publish.crx.password}</password>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/templates/aem-multimodule-project/config/src/main/content/META-INF/vault/config.xml
+++ b/templates/aem-multimodule-project/config/src/main/content/META-INF/vault/config.xml
@@ -1,0 +1,77 @@
+<vaultfs version="1.1">
+    <!--
+        Defines the content aggregation. The order of the defined aggregates
+        is important for finding the correct aggregator.
+    -->
+    <aggregates>
+        <!--
+            Defines an aggregate that handles nt:file and nt:resource nodes.
+        -->
+        <aggregate type="file" title="File Aggregate"/>
+
+        <!--
+            Defines an aggregate that handles file/folder like nodes. It matches
+            all nt:hierarchyNode nodes that have or define a jcr:content
+            child node and excludes child nodes that are nt:hierarchyNodes.
+        -->
+        <aggregate type="filefolder" title="File/Folder Aggregate"/>
+
+        <!--
+            Defines an aggregate that handles nt:nodeType nodes and serializes
+            them into .cnd notation.
+        -->
+        <aggregate type="nodetype" title="Node Type Aggregate" />
+
+        <!--
+            Defines an aggregate that defines full coverage for certain node
+            types that cannot be covered by the default aggregator.
+        -->
+        <aggregate type="full" title="Full Coverage Aggregate">
+            <matches>
+                <include nodeType="rep:AccessControl" respectSupertype="true" />
+                <include nodeType="rep:Policy" respectSupertype="true" />
+                <include nodeType="cq:Widget" respectSupertype="true" />
+                <include nodeType="cq:EditConfig" respectSupertype="true" />
+                <include nodeType="cq:WorkflowModel" respectSupertype="true" />
+                <include nodeType="vlt:FullCoverage" respectSupertype="true" />
+                <include nodeType="mix:language" respectSupertype="true" />
+                <include nodeType="sling:OsgiConfig" respectSupertype="true" />
+            </matches>
+        </aggregate>
+
+        <!--
+            Defines an aggregate that handles nt:folder like nodes.
+        -->
+        <aggregate type="generic" title="Folder Aggregate">
+            <matches>
+                <include nodeType="nt:folder" respectSupertype="true" />
+            </matches>
+            <contains>
+                <exclude isNode="true" />
+            </contains>
+        </aggregate>
+
+        <!--
+            Defines the default aggregate
+        -->
+        <aggregate type="generic" title="Default Aggregator" isDefault="true">
+            <matches>
+                <!-- all -->
+            </matches>
+            <contains>
+                <exclude nodeType="nt:hierarchyNode" respectSupertype="true" />
+            </contains>
+        </aggregate>
+
+    </aggregates>
+
+    <!--
+      defines the input handlers
+    -->
+    <handlers>
+        <handler type="folder"/>
+        <handler type="file"/>
+        <handler type="nodetype"/>
+        <handler type="generic"/>
+    </handlers>
+</vaultfs>

--- a/templates/aem-multimodule-project/config/src/main/content/META-INF/vault/definition/.content.xml
+++ b/templates/aem-multimodule-project/config/src/main/content/META-INF/vault/definition/.content.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:vlt="http://www.day.com/jcr/vault/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+    jcr:description="${projectName} Configuration Package"
+    jcr:primaryType="vlt:PackageDefinition"
+    sling:resourceType="cq/packaging/components/pack/definition"
+    buildCount="1"
+    cqVersion="${aemVersion}"
+    group="${packageGroup}"
+    name="${configArtifactId}"
+    path="/etc/packages/${packageGroup}/${configArtifactId}-${version}"
+    version="${version}">
+    <filter jcr:primaryType="nt:unstructured">
+        <f0
+            jcr:primaryType="nt:unstructured"
+            mode="replace"
+            root="/apps/${appsFolderName}"
+            rules="[include:/apps/${appsFolderName}/config(.*)?]"/>
+    </filter>
+</jcr:root>

--- a/templates/aem-multimodule-project/config/src/main/content/META-INF/vault/filter.xml
+++ b/templates/aem-multimodule-project/config/src/main/content/META-INF/vault/filter.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<workspaceFilter version="1.0">
+    <filter root="/apps/${appsFolderName}">
+            <include pattern="/apps/${appsFolderName}/config(.*)?" />
+    </filter>
+</workspaceFilter>

--- a/templates/aem-multimodule-project/config/src/main/content/META-INF/vault/nodetypes.cnd
+++ b/templates/aem-multimodule-project/config/src/main/content/META-INF/vault/nodetypes.cnd
@@ -1,0 +1,20 @@
+<'cq'='http://www.day.com/jcr/cq/1.0'>
+<'nt'='http://www.jcp.org/jcr/nt/1.0'>
+<'jcr'='http://www.jcp.org/jcr/1.0'>
+<'sling'='http://sling.apache.org/jcr/sling/1.0'>
+<'rep'='internal'>
+
+[cq:Page] > nt:hierarchyNode
+  orderable primaryitem jcr:content
+  + * (nt:base) = nt:base version
+  + jcr:content (nt:base) = nt:unstructured
+
+[sling:Folder] > nt:folder
+  - * (undefined) multiple
+  - * (undefined)
+  + * (nt:base) = sling:Folder version
+
+[rep:RepoAccessControllable]
+  mixin
+  + rep:repoPolicy (rep:Policy) protected ignore
+

--- a/templates/aem-multimodule-project/config/src/main/content/META-INF/vault/properties.xml
+++ b/templates/aem-multimodule-project/config/src/main/content/META-INF/vault/properties.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd">
+<properties>
+<comment>FileVault Package Properties</comment>
+<entry key="buildCount">1</entry>
+<entry key="version">${version}</entry>
+<entry key="dependencies" />
+<entry key="packageFormatVersion">2</entry>
+<entry key="description">${projectName} Configuration Content Package</entry>
+<entry key="group">${packageGroup}</entry>
+<entry key="name">${configArtifactId}</entry>
+<entry key="path">/etc/packages/${packageGroup}/${configArtifactId}-${version}.zip</entry>
+</properties>

--- a/templates/aem-multimodule-project/pom.xml
+++ b/templates/aem-multimodule-project/pom.xml
@@ -345,6 +345,9 @@
 <% } %>
     </profiles>
     <modules>
+        <% if (generateConfigArtifact) { %>
+        <module>config</module>
+        <% } %>
         <module>${bundleInBundlesDirectory ? 'bundles/' : ''}${useNewNamingConvention ? 'core' : 'bundle'}</module>
         <module>${useNewNamingConvention ? 'ui.apps' : 'content'}</module>
         <% if (generateDispatcherArtifact) { %>

--- a/templates/aem-multimodule-project/ui.apps/src/main/content/META-INF/vault/definition/.content.xml
+++ b/templates/aem-multimodule-project/ui.apps/src/main/content/META-INF/vault/definition/.content.xml
@@ -14,7 +14,11 @@
             jcr:primaryType="nt:unstructured"
             mode="replace"
             root="/apps/${appsFolderName}"
+<% if (generateConfigArtifact) { %>
+            rules="[exclude:/apps/${appsFolderName}/config(.*)?]" />
+<% } else { %>
             rules="[]"/>
+<% } %>
 <% if (includeAcsAemCommons && enableErrorHandler) { %>
         <f1
             jcr:primaryType="nt:unstructured"

--- a/templates/aem-multimodule-project/ui.apps/src/main/content/META-INF/vault/filter.xml
+++ b/templates/aem-multimodule-project/ui.apps/src/main/content/META-INF/vault/filter.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <workspaceFilter version="1.0">
-    <filter root="/apps/${appsFolderName}"/>
+    <filter root="/apps/${appsFolderName}">
+<% if (generateConfigArtifact) { %>
+            <exclude pattern="/apps/${appsFolderName}/config(.*)?" />
+<% } %>
+    </filter>
 <% if (includeAcsAemCommons && enableErrorHandler) { %>
     <filter root="/apps/sling/servlet/errorhandler"/>
 <% } %>


### PR DESCRIPTION
It's useful to separate configs from the app code as it allows for deploying configs separately. This feature would allow the user to enable this optional config module in their AEM project.